### PR TITLE
Changed dependencies of components to use tagged releases.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
     },
     "require": {
         "php": ">=5.3.2",
-        "kriswallsmith/buzz": "dev-master",
-        "symfony/console": "dev-master",
-        "symfony/dom-crawler": "dev-master",
-        "symfony/css-selector": "dev-master"
+        "kriswallsmith/buzz": "0.7",
+        "symfony/console": "2.1.*",
+        "symfony/dom-crawler": "2.1.*",
+        "symfony/css-selector": "2.1.*"
     }
 }


### PR DESCRIPTION
I got problems using this library along side https://github.com/hwi/HWIOAuthBundle/ as both require `Buzz` but the bundle is locked on 0.7 and this library is locked on `dev-master`.

This PR fixes this problem and also locks symfony components to the latest stable version.
